### PR TITLE
Added DateTime JSON Formatting

### DIFF
--- a/src/Generator/Property/DateProperty.php
+++ b/src/Generator/Property/DateProperty.php
@@ -23,6 +23,11 @@ class DateProperty extends AbstractPropertyInterface
         $key = $this->key;
         return "\$$key = new \\DateTime(\$input['$key']);";
     }
+    
+    public function convertTypeToJSON($outputVarName = 'output') {
+        $key = $this->key;
+        return "\${$outputVarName}['$key'] = \$this->$key" . "->format(\\DateTime::ATOM);";
+    }
 
     public function cloneProperty()
     {


### PR DESCRIPTION
Right now, the `\DateTime` object is not serialized back into a string for the client. Instead, we are returning the internal properties of `\DateTime` at serialization.

The change below is our desired output when calling `toJson()`

```diff
- "date": {
-   "date": "2019-06-20 03:43:02.000000",
-   "timezone_type": 3,
-   "timezone": "UTC"
- }
+ "date": "2019-06-20T03:43:02+00:00"
```

Example:

<img width="461" alt="Screen Shot 2019-06-19 at 11 23 56 PM" src="https://user-images.githubusercontent.com/3521186/59818390-50ac1180-92e9-11e9-8eb9-97b07b773e4f.png">