### PR TITLE
Add handling for duplicate properties with differently-cased names

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 /.idea/
 /src/Example
 /composer.lock
-/.phpunit.result.cache
+/.phpunit.cache

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -2,6 +2,7 @@
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
          bootstrap="vendor/autoload.php"
+         displayDetailsOnTestsThatTriggerWarnings="true"
          colors="true"
          cacheDirectory=".phpunit.cache">
     <testsuites>

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -8,7 +8,7 @@ use Helmich\Schema2Class\Codegen\PropertyGenerator;
 use Helmich\Schema2Class\Generator\Property\CodeFormatting;
 use Helmich\Schema2Class\Generator\Property\OptionalPropertyDecorator;
 use Helmich\Schema2Class\Generator\Property\PropertyCollection;
-use Helmich\Schema2Class\Generator\Property\PropertyCollectionFilter;
+use Helmich\Schema2Class\Generator\Property\PropertyCollectionFilterFactory;
 use Helmich\Schema2Class\Generator\Property\PropertyInterface;
 use Laminas\Code\Generator\DocBlock\Tag\GenericTag;
 use Laminas\Code\Generator\DocBlock\Tag\ParamTag;
@@ -83,8 +83,8 @@ class Generator
      */
     public function generateBuildMethod(PropertyCollection $properties): MethodGenerator
     {
-        $requiredProperties = $properties->filterRequired();
-        $optionalProperties = $properties->filterOptional();
+        $requiredProperties = $properties->filter(PropertyCollectionFilterFactory::required());
+        $optionalProperties = $properties->filter(PropertyCollectionFilterFactory::optional());
 
         $constructorParams = [];
         $assignments       = [];
@@ -260,7 +260,7 @@ class Generator
     {
         $methods = [];
 
-        $properties = PropertyCollectionFilter::filterWithoutDeprecatedAndSameName($properties);
+        $properties = $properties->filter(PropertyCollectionFilterFactory::withoutDeprecatedAndSameName($properties));
 
         foreach ($properties as $property) {
             $methods[] = $this->generateGetterMethod($property);
@@ -312,12 +312,12 @@ class Generator
     public function generateSetterMethods(PropertyCollection $properties): array
     {
         $methods = [];
-        $properties = PropertyCollectionFilter::filterWithoutDeprecatedAndSameName($properties);
+        $properties = $properties->filter(PropertyCollectionFilterFactory::withoutDeprecatedAndSameName($properties));
 
         foreach ($properties as $property) {
             $methods[] = $this->generateSetterMethod($property);
 
-            if (PropertyCollectionFilter::isOptional($property)) {
+            if ($property instanceof OptionalPropertyDecorator) {
                 $methods[] = $this->generateUnsetterMethod($property);
             }
         }
@@ -406,7 +406,7 @@ return \$clone;",
         $tags        = [];
         $assignments = [];
 
-        $requiredProperties = $properties->filterRequired();
+        $requiredProperties = $properties->filter(PropertyCollectionFilterFactory::required());
 
         foreach ($requiredProperties as $requiredProperty) {
             $paramName = $this->convertToLowerCamelCase($requiredProperty->key());

--- a/src/Generator/Generator.php
+++ b/src/Generator/Generator.php
@@ -8,6 +8,7 @@ use Helmich\Schema2Class\Codegen\PropertyGenerator;
 use Helmich\Schema2Class\Generator\Property\CodeFormatting;
 use Helmich\Schema2Class\Generator\Property\OptionalPropertyDecorator;
 use Helmich\Schema2Class\Generator\Property\PropertyCollection;
+use Helmich\Schema2Class\Generator\Property\PropertyCollectionFilter;
 use Helmich\Schema2Class\Generator\Property\PropertyInterface;
 use Laminas\Code\Generator\DocBlock\Tag\GenericTag;
 use Laminas\Code\Generator\DocBlock\Tag\ParamTag;
@@ -259,6 +260,8 @@ class Generator
     {
         $methods = [];
 
+        $properties = PropertyCollectionFilter::filterWithoutDeprecatedAndSameName($properties);
+
         foreach ($properties as $property) {
             $methods[] = $this->generateGetterMethod($property);
         }
@@ -309,11 +312,12 @@ class Generator
     public function generateSetterMethods(PropertyCollection $properties): array
     {
         $methods = [];
+        $properties = PropertyCollectionFilter::filterWithoutDeprecatedAndSameName($properties);
 
         foreach ($properties as $property) {
             $methods[] = $this->generateSetterMethod($property);
 
-            if ($property instanceof OptionalPropertyDecorator) {
+            if (PropertyCollectionFilter::isOptional($property)) {
                 $methods[] = $this->generateUnsetterMethod($property);
             }
         }

--- a/src/Generator/Property/PropertyCollection.php
+++ b/src/Generator/Property/PropertyCollection.php
@@ -12,6 +12,13 @@ class PropertyCollection implements \Iterator
 
     private int $current = 0;
 
+    public static function fromArray(array $properties): PropertyCollection
+    {
+        $collection = new PropertyCollection();
+        $collection->properties = $properties;
+        return $collection;
+    }
+
     public function add(PropertyInterface $propertyGenerator): void
     {
         $this->properties[] = $propertyGenerator;

--- a/src/Generator/Property/PropertyCollection.php
+++ b/src/Generator/Property/PropertyCollection.php
@@ -17,11 +17,6 @@ class PropertyCollection implements \Iterator
         $this->properties[] = $propertyGenerator;
     }
 
-    /**
-     * @param string $inputVarName
-     * @param bool   $object
-     * @return string
-     */
     public function generateJSONToTypeConversionCode(string $inputVarName = 'input', bool $object = false): string
     {
         $conv = [];
@@ -33,10 +28,6 @@ class PropertyCollection implements \Iterator
         return join("\n", $conv);
     }
 
-    /**
-     * @param string $outputVarName
-     * @return string
-     */
     public function generateTypeToJSONConversionCode(string $outputVarName = 'output'): string
     {
         $conv = [];
@@ -48,10 +39,6 @@ class PropertyCollection implements \Iterator
         return join("\n", $conv);
     }
 
-    /**
-     * @param string $key
-     * @return bool
-     */
     public function hasPropertyWithKey(string $key): bool
     {
         foreach ($this->properties as $p) {

--- a/src/Generator/Property/PropertyCollection.php
+++ b/src/Generator/Property/PropertyCollection.php
@@ -19,23 +19,13 @@ class PropertyCollection implements \Iterator
 
     public function generateJSONToTypeConversionCode(string $inputVarName = 'input', bool $object = false): string
     {
-        $conv = [];
-
-        foreach ($this->properties as $generator) {
-            $conv[] = $generator->convertJSONToType($inputVarName, $object);
-        }
-
+        $conv = array_map(fn ($p) => $p->convertJSONToType($inputVarName, $object), $this->properties);
         return join("\n", $conv);
     }
 
     public function generateTypeToJSONConversionCode(string $outputVarName = 'output'): string
     {
-        $conv = [];
-
-        foreach ($this->properties as $generator) {
-            $conv[] = $generator->convertTypeToJSON($outputVarName);
-        }
-
+        $conv = array_map(fn ($p) => $p->convertTypeToJSON($outputVarName), $this->properties);
         return join("\n", $conv);
     }
 
@@ -55,9 +45,7 @@ class PropertyCollection implements \Iterator
      */
     public function filterRequired(): array
     {
-        return array_filter($this->properties, function($p) {
-            return !($p instanceof OptionalPropertyDecorator);
-        });
+        return array_filter($this->properties, fn ($p) => !$this->isOptional($p));
     }
 
     /**
@@ -65,9 +53,7 @@ class PropertyCollection implements \Iterator
      */
     public function filterOptional(): array
     {
-        return array_filter($this->properties, function($p) {
-            return $p instanceof OptionalPropertyDecorator;
-        });
+        return array_filter($this->properties, fn ($p) => $this->isOptional($p));
     }
 
     public function isOptional(PropertyInterface $prop): bool

--- a/src/Generator/Property/PropertyCollection.php
+++ b/src/Generator/Property/PropertyCollection.php
@@ -15,7 +15,7 @@ class PropertyCollection implements \Iterator
     public static function fromArray(array $properties): PropertyCollection
     {
         $collection = new PropertyCollection();
-        $collection->properties = $properties;
+        $collection->properties = array_values($properties);
         return $collection;
     }
 
@@ -47,20 +47,17 @@ class PropertyCollection implements \Iterator
         return false;
     }
 
-    /**
-     * @return PropertyInterface[]
-     */
-    public function filterRequired(): array
+    public function filter(PropertyCollectionFilter $filter): PropertyCollection
     {
-        return array_filter($this->properties, fn ($p) => !$this->isOptional($p));
-    }
+        $matching = [];
 
-    /**
-     * @return PropertyInterface[]
-     */
-    public function filterOptional(): array
-    {
-        return array_filter($this->properties, fn ($p) => $this->isOptional($p));
+        foreach ($this->properties as $property) {
+            if ($filter->apply($property)) {
+                $matching[] = $property;
+            }
+        }
+
+        return PropertyCollection::fromArray($matching);
     }
 
     public function isOptional(PropertyInterface $prop): bool

--- a/src/Generator/Property/PropertyCollectionFilter.php
+++ b/src/Generator/Property/PropertyCollectionFilter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Helmich\Schema2Class\Generator\Property;
+
+class PropertyCollectionFilter
+{
+    public static function filterWithoutDeprecatedAndSameName(PropertyCollection $input): PropertyCollection {
+        /** @var PropertyInterface[] $properties */
+        $properties = iterator_to_array($input);
+        $propertyNamesCaseInsensitive = array_unique(array_map(fn (PropertyInterface $p) => strtolower($p->key()), $properties));
+
+        $filtered = [];
+
+        foreach ($properties as $property) {
+            if ($property->schema()["deprecated"] && in_array(strtolower($property->key()), $propertyNamesCaseInsensitive)) {
+                continue;
+            }
+
+            $filtered[] = $property;
+        }
+
+        return PropertyCollection::fromArray($filtered);
+    }
+
+    public static function isOptional(PropertyInterface $property): bool {
+        return $property instanceof OptionalPropertyDecorator;
+    }
+}

--- a/src/Generator/Property/PropertyCollectionFilter.php
+++ b/src/Generator/Property/PropertyCollectionFilter.php
@@ -1,28 +1,7 @@
 <?php
-
 namespace Helmich\Schema2Class\Generator\Property;
 
-class PropertyCollectionFilter
+interface PropertyCollectionFilter
 {
-    public static function filterWithoutDeprecatedAndSameName(PropertyCollection $input): PropertyCollection {
-        /** @var PropertyInterface[] $properties */
-        $properties = iterator_to_array($input);
-        $propertyNamesCaseInsensitive = array_unique(array_map(fn (PropertyInterface $p) => strtolower($p->key()), $properties));
-
-        $filtered = [];
-
-        foreach ($properties as $property) {
-            if ($property->schema()["deprecated"] && in_array(strtolower($property->key()), $propertyNamesCaseInsensitive)) {
-                continue;
-            }
-
-            $filtered[] = $property;
-        }
-
-        return PropertyCollection::fromArray($filtered);
-    }
-
-    public static function isOptional(PropertyInterface $property): bool {
-        return $property instanceof OptionalPropertyDecorator;
-    }
+    function apply(PropertyInterface $property): bool;
 }

--- a/src/Generator/Property/PropertyCollectionFilterFactory.php
+++ b/src/Generator/Property/PropertyCollectionFilterFactory.php
@@ -2,6 +2,8 @@
 
 namespace Helmich\Schema2Class\Generator\Property;
 
+use Helmich\Schema2Class\Generator\PropertyQuery;
+
 readonly class PropertyCollectionFilterFactory
 {
     public static function withoutDeprecatedAndSameName(PropertyCollection $properties): PropertyCollectionFilter
@@ -23,13 +25,10 @@ readonly class PropertyCollectionFilterFactory
 
             public function apply(PropertyInterface $property): bool
             {
-                $schema = $property->schema();
-
-                $isDeprecated = isset($schema["deprecated"]) && $schema["deprecated"];
                 $matchingProperties = $this->propertyNamesCaseInsensitive[strtolower($property->key())];
                 $matchingPropertiesWithDifferentCase = array_filter($matchingProperties, fn($name) => $name !== $property->key());
 
-                if ($isDeprecated && count($matchingPropertiesWithDifferentCase) > 0) {
+                if (PropertyQuery::isDeprecated($property) && count($matchingPropertiesWithDifferentCase) > 0) {
                     return false;
                 }
 

--- a/src/Generator/Property/PropertyCollectionFilterFactory.php
+++ b/src/Generator/Property/PropertyCollectionFilterFactory.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Helmich\Schema2Class\Generator\Property;
+
+readonly class PropertyCollectionFilterFactory
+{
+    public static function withoutDeprecatedAndSameName(PropertyCollection $properties): PropertyCollectionFilter
+    {
+        return new class($properties) implements PropertyCollectionFilter {
+            private array $propertyNamesCaseInsensitive;
+
+            public function __construct(PropertyCollection $properties)
+            {
+                /** @var PropertyInterface[] $properties */
+                $properties                         = iterator_to_array($properties);
+                $this->propertyNamesCaseInsensitive = array_unique(array_map(fn(PropertyInterface $p) => strtolower($p->key()), $properties));
+            }
+
+            public function apply(PropertyInterface $property): bool
+            {
+                if ($property->schema()["deprecated"] && in_array(strtolower($property->key()), $this->propertyNamesCaseInsensitive)) {
+                    return false;
+                }
+
+                return true;
+            }
+        };
+    }
+
+    public static function optional(): PropertyCollectionFilter
+    {
+        return new class implements PropertyCollectionFilter {
+            public function apply(PropertyInterface $property): bool
+            {
+                return $property instanceof OptionalPropertyDecorator;
+            }
+        };
+    }
+
+    public static function required(): PropertyCollectionFilter
+    {
+        return new class implements PropertyCollectionFilter {
+            public function apply(PropertyInterface $property): bool
+            {
+                return !($property instanceof OptionalPropertyDecorator);
+            }
+        };
+    }
+}

--- a/src/Generator/PropertyQuery.php
+++ b/src/Generator/PropertyQuery.php
@@ -1,0 +1,13 @@
+<?php
+namespace Helmich\Schema2Class\Generator;
+
+use Helmich\Schema2Class\Generator\Property\PropertyInterface;
+
+class PropertyQuery
+{
+    public static function isDeprecated(PropertyInterface $property): bool
+    {
+        $schema = $property->schema();
+        return isset($schema["deprecated"]) && $schema["deprecated"];
+    }
+}

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output/Foo.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output/Foo.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\Basic;
+
+class Foo
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     *
+     * @var array
+     */
+    private static array $schema = [
+        'required' => [
+            'fooBar',
+        ],
+        'properties' => [
+            'foobar' => [
+                'type' => 'string',
+                'deprecated' => true,
+            ],
+            'fooBar' => [
+                'type' => 'string',
+            ],
+        ],
+    ];
+
+    /**
+     * @var string|null
+     */
+    private ?string $foobar = null;
+
+    /**
+     * @var string
+     */
+    private string $fooBar;
+
+    /**
+     * @param string $fooBar
+     */
+    public function __construct(string $fooBar)
+    {
+        $this->fooBar = $fooBar;
+    }
+
+    /**
+     * @return string
+     */
+    public function getFooBar() : string
+    {
+        return $this->fooBar;
+    }
+
+    /**
+     * @param string $fooBar
+     * @return self
+     */
+    public function withFooBar(string $fooBar) : self
+    {
+        $validator = new \JsonSchema\Validator();
+        $validator->validate($fooBar, static::$schema['properties']['foo_bar']);
+        if (!$validator->isValid()) {
+            throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+        }
+
+        $clone = clone $this;
+        $clone->fooBar = $fooBar;
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $validate Set this to false to skip validation; use at own risk
+     * @return Foo Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $fooBar = $input->{'fooBar'};
+
+        $obj = new self($fooBar);
+        $obj->fooBar = $fooBar;
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toJson() : array
+    {
+        $output = [];
+        $output['fooBar'] = $this->fooBar;
+
+        return $output;
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false) : bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, static::$schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return $e["property"] . ": " . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(", ", $errors));
+        }
+
+        return $validator->isValid();
+    }
+
+    public function __clone()
+    {
+    }
+}

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output/Foo.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output/Foo.php
@@ -28,6 +28,7 @@ class Foo
 
     /**
      * @var string|null
+     * @deprecated
      */
     private ?string $foobar = null;
 

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output/Foo.php
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/Output/Foo.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace Ns\Basic;
+namespace Ns\DuplicateWithDifferentCasing;
 
 class Foo
 {
@@ -59,7 +59,7 @@ class Foo
     public function withFooBar(string $fooBar) : self
     {
         $validator = new \JsonSchema\Validator();
-        $validator->validate($fooBar, static::$schema['properties']['foo_bar']);
+        $validator->validate($fooBar, static::$schema['properties']['fooBar']);
         if (!$validator->isValid()) {
             throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
         }
@@ -85,10 +85,14 @@ class Foo
             static::validateInput($input);
         }
 
+        $foobar = null;
+        if (isset($input->{'foobar'})) {
+            $foobar = $input->{'foobar'};
+        }
         $fooBar = $input->{'fooBar'};
 
         $obj = new self($fooBar);
-        $obj->fooBar = $fooBar;
+        $obj->foobar = $foobar;
         return $obj;
     }
 
@@ -100,6 +104,9 @@ class Foo
     public function toJson() : array
     {
         $output = [];
+        if (isset($this->foobar)) {
+            $output['foobar'] = $this->foobar;
+        }
         $output['fooBar'] = $this->fooBar;
 
         return $output;

--- a/tests/Generator/Fixtures/DuplicateWithDifferentCasing/schema.yaml
+++ b/tests/Generator/Fixtures/DuplicateWithDifferentCasing/schema.yaml
@@ -1,0 +1,8 @@
+required:
+  - fooBar
+properties:
+  foobar:
+    type: string
+    deprecated: true
+  fooBar:
+    type: string


### PR DESCRIPTION
- **Add failing test case**
- **Remove superflous doccomments**
- **Simplify PropertyCollection**
- **Ignore .phpunit.cache**
- **Add handling for properties with duplicated names with different casing**
- **Refactoring**
- **Fix PHPUnit warnings, improve readability**
- **Generate @deprecated annotations for properties/getter/setters where applicable**
