### PR TITLE
feat: ensure that number of written files equals to count of expected

### DIFF
--- a/tests/Generator/SchemaToClassTest.php
+++ b/tests/Generator/SchemaToClassTest.php
@@ -120,7 +120,7 @@ class SchemaToClassTest extends TestCase
             expectedCount: count($expectedOutput),
             haystack: $writer->getWrittenFiles(),
             message: sprintf(
-                'Expected files [%s] does not match count written files [%s]',
+                'Expected file count [%s] does not match the written file count [%s]',
                 implode(', ', array_keys($expectedOutput)),
                 implode(', ', array_keys($writer->getWrittenFiles())),
             ),

--- a/tests/Generator/SchemaToClassTest.php
+++ b/tests/Generator/SchemaToClassTest.php
@@ -116,6 +116,15 @@ class SchemaToClassTest extends TestCase
 
         (new SchemaToClassFactory())->build($writer, $output)->schemaToClass($req);
 
+        $this->assertCount(
+            expectedCount: count($expectedOutput),
+            haystack: $writer->getWrittenFiles(),
+            message: sprintf(
+                'Expected files [%s] does not match count written files [%s]',
+                implode(', ', array_keys($expectedOutput)),
+                implode(', ', array_keys($writer->getWrittenFiles())),
+            ),
+        );
         foreach ($expectedOutput as $file => $content) {
             $filename      = join(DIRECTORY_SEPARATOR, [__DIR__, $file]);
             $actualContent = $writer->getWrittenFiles()[$filename];


### PR DESCRIPTION
Currently, it could happen that we write more files than we tested for, this assertion makes sure that we test every file that was generated

Example output:
```bash
There was 1 failure:

1) Helmich\Schema2Class\Generator\SchemaToClassTest::testCodeGeneration with data set "Definitions" ('Definitions', ['http://json-schema.org/draft-...chema#', 'http://json-schema.org/draft-...chema#', 'definitions test', 'object', false, [['object', false, [['#/definitions/country']], ['country']], ['object', false, [['string', 'ISO-3166 country name'], ['string', 'ISO-3166-1 alpha-3 country code']], ['name', 'code']]], [['object', false, [['string'], ['#/definitions/address']], ['address']]], ['customer']], ['<?php\n\ndeclare(strict_types...  }\n}'], Helmich\Schema2Class\Spec\SpecificationOptions Object (...))
Expected file count [Foo.php] does not match the written file count [/Users/simivar/PhpstormProjects/php-schema2class/tests/Generator/FooCustomer.php, /Users/simivar/PhpstormProjects/php-schema2class/tests/Generator/Foo.php]
Failed asserting that actual size 2 matches expected size 1.

/Users/simivar/PhpstormProjects/php-schema2class/tests/Generator/SchemaToClassTest.php:128

FAILURES!
Tests: 109, Assertions: 200, Failures: 1.
```