### PR TITLE
feat: add test for .json file

### DIFF
--- a/tests/Generator/Fixtures/JsonFile/Output/Foo.php
+++ b/tests/Generator/Fixtures/JsonFile/Output/Foo.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ns\JsonFile;
+
+class Foo
+{
+    /**
+     * Schema used to validate input for creating instances of this class
+     *
+     * @var array
+     */
+    private static array $schema = [
+        '$schema' => 'http://json-schema.org/draft-07/schema#',
+        '$id' => 'http://json-schema.org/draft-07/schema#',
+        'title' => 'definitions test',
+        'type' => 'object',
+        'additionalProperties' => false,
+        'properties' => [
+            'id' => [
+                'type' => 'integer',
+            ],
+        ],
+        'required' => [
+            'id',
+        ],
+    ];
+
+    /**
+     * @var int
+     */
+    private int $id;
+
+    /**
+     * @param int $id
+     */
+    public function __construct(int $id)
+    {
+        $this->id = $id;
+    }
+
+    /**
+     * @return int
+     */
+    public function getId() : int
+    {
+        return $this->id;
+    }
+
+    /**
+     * @param int $id
+     * @return self
+     */
+    public function withId(int $id) : self
+    {
+        $validator = new \JsonSchema\Validator();
+        $validator->validate($id, static::$schema['properties']['id']);
+        if (!$validator->isValid()) {
+            throw new \InvalidArgumentException($validator->getErrors()[0]['message']);
+        }
+
+        $clone = clone $this;
+        $clone->id = $id;
+
+        return $clone;
+    }
+
+    /**
+     * Builds a new instance from an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $validate Set this to false to skip validation; use at own risk
+     * @return Foo Created instance
+     * @throws \InvalidArgumentException
+     */
+    public static function buildFromInput(array|object $input, bool $validate = true) : Foo
+    {
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        if ($validate) {
+            static::validateInput($input);
+        }
+
+        $id = (int)($input->{'id'});
+
+        $obj = new self($id);
+
+        return $obj;
+    }
+
+    /**
+     * Converts this object back to a simple array that can be JSON-serialized
+     *
+     * @return array Converted array
+     */
+    public function toJson() : array
+    {
+        $output = [];
+        $output['id'] = $this->id;
+
+        return $output;
+    }
+
+    /**
+     * Validates an input array
+     *
+     * @param array|object $input Input data
+     * @param bool $return Return instead of throwing errors
+     * @return bool Validation result
+     * @throws \InvalidArgumentException
+     */
+    public static function validateInput(array|object $input, bool $return = false) : bool
+    {
+        $validator = new \JsonSchema\Validator();
+        $input = is_array($input) ? \JsonSchema\Validator::arrayToObjectRecursive($input) : $input;
+        $validator->validate($input, static::$schema);
+
+        if (!$validator->isValid() && !$return) {
+            $errors = array_map(function(array $e): string {
+                return $e["property"] . ": " . $e["message"];
+            }, $validator->getErrors());
+            throw new \InvalidArgumentException(join(", ", $errors));
+        }
+
+        return $validator->isValid();
+    }
+
+    public function __clone()
+    {
+    }
+}

--- a/tests/Generator/Fixtures/JsonFile/schema.json
+++ b/tests/Generator/Fixtures/JsonFile/schema.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://json-schema.org/draft-07/schema#",
+  "title": "definitions test",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "id": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "id"
+  ]
+}

--- a/tests/Generator/SchemaToClassTest.php
+++ b/tests/Generator/SchemaToClassTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace Helmich\Schema2Class\Generator;
 
 use Helmich\Schema2Class\Example\CustomerAddress;
+use Helmich\Schema2Class\Loader\SchemaLoader;
 use Helmich\Schema2Class\Spec\SpecificationOptions;
 use Helmich\Schema2Class\Spec\ValidatedSpecificationFilesItem;
 use Helmich\Schema2Class\Writer\DebugWriter;
@@ -33,6 +34,10 @@ class SchemaToClassTest extends TestCase
             }
 
             $schemaFile = join(DIRECTORY_SEPARATOR, [$testCaseDir, $entry, "schema.yaml"]);
+            if (!file_exists($schemaFile)) {
+                $schemaFile = join(DIRECTORY_SEPARATOR, [$testCaseDir, $entry, "schema.json"]);
+            }
+
             $optionsFile = join(DIRECTORY_SEPARATOR, [$testCaseDir, $entry, "options.yaml"]);
             $outputDir  = join(DIRECTORY_SEPARATOR, [$testCaseDir, $entry, "Output"]);
             $output     = @opendir($outputDir);
@@ -42,7 +47,7 @@ class SchemaToClassTest extends TestCase
             }
 
             $expectedFiles = [];
-            $schema        = Yaml::parseFile($schemaFile);
+            $schema        = (new SchemaLoader())->loadSchema($schemaFile);
 
             $opts = (new SpecificationOptions)
                 ->withTargetPHPVersion("8.2")


### PR DESCRIPTION
This PR adds a simple JSON file test alongside the existing YAML-based tests

Why?
1. To ensure JSON files load correctly
1. To better align tests with real-world examples, which are often in JSON. This avoids unnecessary JSON-to-YAML conversion and simplifies adding failing test cases for bug reports