### PR TITLE
bc-break feat: implement EnumGenerator using nikic/PHP-parser

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "justinrainbow/json-schema": "^6.0",
         "ext-json": "*",
         "composer/semver": "^3.0",
-        "laminas/laminas-code": "^4.12"
+        "laminas/laminas-code": "^4.12",
+        "nikic/php-parser": "^4.19"
     },
     "autoload": {
         "psr-4": {

--- a/src/Codegen/AbstractGenerator.php
+++ b/src/Codegen/AbstractGenerator.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class\Codegen;
+
+use PhpParser\Node;
+
+abstract class AbstractGenerator
+{
+    /**
+     * @param Node[] $nodes
+     */
+    public function __construct(protected array $nodes)
+    {
+    }
+
+    public function insert(int $index, Node $node): self
+    {
+        array_splice($this->nodes, $index, 0, $node);
+
+        return $this;
+    }
+
+    public function set(int $index, $value): self
+    {
+        if (!$this->isValidIndex($index)) {
+            throw new \OutOfRangeException();
+        }
+
+        $this->nodes[$index] = $value;
+
+        return $this;
+    }
+
+    public function remove(int $index): Node
+    {
+        if (!$this->isValidIndex($index)) {
+            throw new \OutOfRangeException();
+        }
+
+        return array_splice($this->nodes, $index, 1, null)[0];
+    }
+
+    public function clear(): self
+    {
+        $this->nodes = [];
+
+        return $this;
+    }
+
+    /**
+     * @psalm-param callable(Node): Node $callback
+     */
+    public function apply(callable $callback): self
+    {
+        foreach ($this->nodes as &$value) {
+            $value = $callback($value);
+        }
+
+        return $this;
+    }
+
+    public function filter(callable $callback = null): self
+    {
+        return new static(array_filter($this->nodes, $callback ?: 'boolval'));
+    }
+
+    public function find(Node $value): ?int
+    {
+        $offset = array_search($value, $this->nodes, true);
+
+        return $offset === false ? null : $offset;
+    }
+
+    public function first(): Node
+    {
+        if (empty($this->nodes)) {
+            throw new \UnderflowException();
+        }
+
+        return $this->nodes[0];
+    }
+
+    public function get(int $index): Node
+    {
+        if (!$this->isValidIndex($index)) {
+            throw new \OutOfRangeException();
+        }
+
+        return $this->nodes[$index];
+    }
+
+    public function last(): Node
+    {
+        return $this->nodes[array_key_last($this->nodes)];
+    }
+
+    protected function isValidIndex(int $index): bool
+    {
+        return array_key_exists($index, $this->nodes);
+    }
+}

--- a/src/Codegen/EnumGenerator.php
+++ b/src/Codegen/EnumGenerator.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Helmich\Schema2Class\Codegen;
+
+use PhpParser\Node\Identifier;
+use PhpParser\Node\Scalar\LNumber;
+use PhpParser\Node\Stmt\Declare_;
+use PhpParser\Node\Stmt\DeclareDeclare;
+use PhpParser\Node\Stmt\Enum_;
+use PhpParser\Node\Stmt\EnumCase;
+use PhpParser\Node\Stmt\Namespace_;
+use PhpParser\Node\Stmt\Nop;
+use PhpParser\PrettyPrinter\Standard;
+
+class EnumGenerator extends AbstractGenerator
+{
+    /** @var array<non-empty-string, EnumCase> */
+    protected array $cases = [];
+
+    public function __construct(
+        protected Enum_ $enum_,
+        protected Namespace_ $namespace_
+    )
+    {
+        parent::__construct([
+            $this->buildStrictTypes(),
+            new Nop(),
+            $this->namespace_,
+            $this->enum_,
+        ]);
+    }
+
+    public function withEnum_(Enum_ $enum_): self
+    {
+        foreach ($this->cases as $name => $case) {
+            $enum_->stmts[$name] = $case;
+        }
+
+        $currentEnumIndex = $this->find($this->enum_);
+        if ($currentEnumIndex !== null) {
+            $this->set($currentEnumIndex, $enum_);
+        }
+
+        $this->enum_ = $enum_;
+
+        return $this;
+    }
+
+    public function withNamespace_(Namespace_ $namespace_): self
+    {
+        $currentNamespaceIndex = $this->find($this->namespace_);
+        if ($currentNamespaceIndex !== null) {
+            $this->set($currentNamespaceIndex, $namespace_);
+        }
+
+        $this->namespace_ = $namespace_;
+
+        return $this;
+    }
+
+    public function withAdditionalEnumCase(EnumCase $enumCase): self
+    {
+        $this->cases[$enumCase->name->toLowerString()] = $enumCase;
+        $this->enum_->stmts[$enumCase->name->toString()] = $enumCase;
+
+        return $this;
+    }
+
+    protected function buildStrictTypes(): Declare_
+    {
+        $declareDeclare = new DeclareDeclare(new Identifier('strict_types'), new LNumber(1));
+        return new Declare_([$declareDeclare]);
+    }
+
+    public function generate(): string
+    {
+        $prettyPrinter = new Standard();
+        return $prettyPrinter->prettyPrint($this->nodes);
+    }
+}

--- a/src/Generator/GeneratorHookRunner.php
+++ b/src/Generator/GeneratorHookRunner.php
@@ -2,8 +2,8 @@
 
 namespace Helmich\Schema2Class\Generator;
 
+use Helmich\Schema2Class\Codegen\EnumGenerator;
 use Laminas\Code\Generator\ClassGenerator;
-use Laminas\Code\Generator\EnumGenerator\EnumGenerator;
 use Laminas\Code\Generator\FileGenerator;
 
 trait GeneratorHookRunner

--- a/src/Generator/Hook/EnumCreatedHook.php
+++ b/src/Generator/Hook/EnumCreatedHook.php
@@ -2,7 +2,7 @@
 
 namespace Helmich\Schema2Class\Generator\Hook;
 
-use Laminas\Code\Generator\EnumGenerator\EnumGenerator;
+use Helmich\Schema2Class\Codegen\EnumGenerator;
 
 /**
  * Interface definition for hooks that are called when an enumeration is created.

--- a/src/Generator/SchemaToClass.php
+++ b/src/Generator/SchemaToClass.php
@@ -12,7 +12,6 @@ use Laminas\Code\DeclareStatement;
 use Laminas\Code\Generator\ClassGenerator;
 use Laminas\Code\Generator\DocBlock\Tag\GenericTag;
 use Laminas\Code\Generator\DocBlockGenerator;
-use Laminas\Code\Generator\EnumGenerator\EnumGenerator;
 use Laminas\Code\Generator\FileGenerator;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/tests/Generator/Fixtures/Enum/Output/Foo.php
+++ b/tests/Generator/Fixtures/Enum/Output/Foo.php
@@ -1,10 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare (strict_types=1);
 
 namespace Ns\Enum;
 
-enum Foo: string {
+enum Foo : string
+{
     case Foo = 'Foo';
     case Bar = 'Bar';
     case Baz = 'Baz';

--- a/tests/Generator/Fixtures/EnumConsistent/Output/Foo.php
+++ b/tests/Generator/Fixtures/EnumConsistent/Output/Foo.php
@@ -1,10 +1,11 @@
 <?php
 
-declare(strict_types=1);
+declare (strict_types=1);
 
 namespace Ns\EnumConsistent;
 
-enum Foo: string {
+enum Foo : string
+{
     case VALUE_Foo = 'Foo';
     case VALUE_1Foo = '1Foo';
 }

--- a/tests/Generator/Fixtures/EnumHook/Output/Foo.php
+++ b/tests/Generator/Fixtures/EnumHook/Output/Foo.php
@@ -1,0 +1,14 @@
+<?php
+
+declare (strict_types=1);
+
+namespace Ns\EnumHook;
+
+/** Doc comment */
+enum Foo : string
+{
+    case red = 'red';
+    case amber = 'amber';
+    case green = 'green';
+    case blue = 'blue';
+}

--- a/tests/Generator/Fixtures/EnumHook/schema.json
+++ b/tests/Generator/Fixtures/EnumHook/schema.json
@@ -1,0 +1,4 @@
+{
+  "type": "string",
+  "enum": [ "red", "amber", "green" ]
+}


### PR DESCRIPTION
This commit introduces a new and custom EnumGenerator to address the limitations we faced with the immutable Laminas' EnumGenerator

Instead of relying on the Laminas' generator, we've now built our own generator using the [nikic/PHP-Parser](https://github.com/nikic/PHP-Parser) package. By making this switch, we've successfully removed the need for reflection to modify properties - something we had to do with the old EnumGenerator. Moreover, with the provided user-friendly function applied to the `nodes`, end-users can add virtually any PHP statement that the [`nikic/php-parser`](https://github.com/nikic/PHP-Parser) package supports

If this solution is accepted we can do the same changes for the rest of hooks and generators